### PR TITLE
Csource rfname parameter

### DIFF
--- a/inst/examples/csource.R
+++ b/inst/examples/csource.R
@@ -4,6 +4,7 @@
 csource <- function(
     fname,
     libname=NULL,  # defaults to the base name of `fname` without extension
+    rfname=NULL, # R file with function calling package's funcs. defaults to extracting from .c file
     shlibargs=character(),
     headers=paste0(
         "#include <R.h>\n",
@@ -17,6 +18,7 @@ csource <- function(
     stopifnot(is.character(shlibargs))
     stopifnot(is.character(headers))
     stopifnot(is.character(R), length(R) == 1)
+    stopifnot(is.null(rfname) | file.exists(rfname))
 
     if (is.null(libname))
         libname <- regmatches(basename(fname),

--- a/inst/examples/csource.R
+++ b/inst/examples/csource.R
@@ -4,7 +4,7 @@
 csource <- function(
     fname,
     libname=NULL,  # defaults to the base name of `fname` without extension
-    rfname=NULL, # R file with function calling package's funcs. defaults to extracting from .c file
+    rfname=NULL, # R file with function calling package's funcs. defaults to extracting from fname file
     shlibargs=character(),
     headers=paste0(
         "#include <R.h>\n",

--- a/inst/examples/csource.R
+++ b/inst/examples/csource.R
@@ -18,7 +18,7 @@ csource <- function(
     stopifnot(is.character(shlibargs))
     stopifnot(is.character(headers))
     stopifnot(is.character(R), length(R) == 1)
-    stopifnot(is.null(rfname) | file.exists(rfname))
+    stopifnot(is.null(rfname) || file.exists(rfname))
 
     if (is.null(libname))
         libname <- regmatches(basename(fname),

--- a/inst/examples/helloworld.R
+++ b/inst/examples/helloworld.R
@@ -1,0 +1,5 @@
+hello_c_nor <- function()
+    invisible(.Call("C_hello", PACKAGE="helloworld_norcode"))
+
+hello_c <- function()
+    invisible(.Call("C_hello", PACKAGE="helloworld_rcode"))

--- a/inst/examples/helloworld_norcode.c
+++ b/inst/examples/helloworld_norcode.c
@@ -1,0 +1,8 @@
+// the necessary header files are automatically included by `csource`
+
+SEXP C_hello()
+{
+    Rprintf("Hello from C code without R code embedded\n");
+    return R_NilValue;
+}
+

--- a/inst/examples/helloworld_rcode.c
+++ b/inst/examples/helloworld_rcode.c
@@ -1,0 +1,15 @@
+// the necessary header files are automatically included by `csource`
+
+SEXP C_hello()
+{
+    Rprintf("Hello from C with R code embedded\n");
+    return R_NilValue;
+}
+
+/* R
+# this chunk will be extracted and executed by `csource`.
+
+hello <- function()
+    invisible(.Call("C_hello", PACKAGE="helloworld_rcode"))
+
+R */

--- a/inst/examples/sexptype.c
+++ b/inst/examples/sexptype.c
@@ -2,7 +2,7 @@ SEXP C_test_sexptype(SEXP x)
 {
     Rprintf("type of x: %s (SEXPTYPE=%d)\n",
         Rf_type2char(TYPEOF(x)),
-        (int)TYPEOF(x)
+        TYPEOF(x)
     );
     return R_NilValue;
 }


### PR DESCRIPTION
I'd like to propose this change to the demo.
I think the change to the book would also be needed if you accept this change.

My general idea is to draw your attention to few points:

1. We can add `rfname` parameter to the `csource` function if we'd like to just create the .R file with proper functions which call C code. It's more natural than extracting the R code from c-file comments. Of course in case you had something specific to education process in mind I just put also possibility to pass NULL and extract the R code as previously.
2. I think deleting the comments containing R function code from the C code is not necessary before compilation as C compiler will ignore these lines.
3. I added separate C files and R file to test the new approach but also tested if the old one still works as you intended.

I'm curious what you think on this matter.